### PR TITLE
Fix extraction issues with AirPods Pro 3 firmware

### DIFF
--- a/src/rkos_parser.rs
+++ b/src/rkos_parser.rs
@@ -90,10 +90,14 @@ pub fn parse_ftab<R>(src: &mut R) -> std::io::Result<Ftab>
             src.read_u32::<LittleEndian>()?,
         );
 
-        entries.push(entry.clone());
-
         // pad
         src.read_u32::<LittleEndian>()?;
+
+        if entry.2 <= 0 { // occurs on AirPods Pro 3 firmware
+            continue;
+        }
+
+        entries.push(entry.clone());
 
         if i != 0 {
             let prev_entry = &entries.get(i - 1usize).unwrap();


### PR DESCRIPTION
Currently, upon trying to extract either the CTAB.bin or FTAB.bin firmwares in the AirPods Pro 3 UARP, there is an assertion failure of "Error: offset not within alignment of 4 bytes". This is caused by the fact that in both of these FTABs, the `sbd2` component has an offset and size of 0, causing the assert to fail upon comparing previous offsets. I have fixed this through simply ignoring components with a size of 0 as they do not exist in the FTAB, please take a look and let me know if there are any issues. Thanks!